### PR TITLE
[wip] downwards pass through tiles

### DIFF
--- a/app/game/player.rb
+++ b/app/game/player.rb
@@ -180,6 +180,7 @@ class Player < Actor
       destroy
     end
     @y_speed = 0
+    $falling_through = false
     super
   end
 

--- a/app/game/starter_level.rb
+++ b/app/game/starter_level.rb
@@ -56,10 +56,18 @@ def tick args
     @player.move_right if args.state.active_input.key_held?(control_mapping[:right])
     @player.climb if args.state.active_input.key_held?(control_mapping[:climb])
     @player.move_up if args.state.active_input.key_held?(control_mapping[:up])
-    @player.move_down if args.state.active_input.key_held?(control_mapping[:down])
-    if args.state.active_input.key_down_or_held?(control_mapping[:jump])
-      @player.jump if args.state.active_input.key_down?(control_mapping[:jump])
-      @player.jump_accelerate if args.state.active_input.key_held?(control_mapping[:jump])
+    if args.state.active_input.key_held?(control_mapping[:down])
+      if args.state.active_input.key_down_or_held?(control_mapping[:jump])
+        # if we are standing on top of a passable floor, pass down through it!
+        $falling_through = true
+      else
+        @player.move_down
+      end
+    else
+      if args.state.active_input.key_down_or_held?(control_mapping[:jump])
+        @player.jump if args.state.active_input.key_down?(control_mapping[:jump])
+        @player.jump_accelerate if args.state.active_input.key_held?(control_mapping[:jump])
+      end
     end
     @player.fire(@camera.mouse_x, @camera.mouse_y) if args.inputs.mouse.click
   end

--- a/app/lib/map.rb
+++ b/app/lib/map.rb
@@ -110,7 +110,7 @@ class Map
             solids << s
           when TILE_JUMP_THROUGH
             # only triggers if movement direction is downwards and actor is at highest point of solid
-            if dir_y < 0 && y == (_y + i + 1) * @tile_size * @scale
+            if dir_y < 0 && y == (_y + i + 1) * @tile_size * @scale && !$falling_through
               solids << s
             end
           end


### PR DESCRIPTION
When the player is standing on top of a tile they can pass through from the bottom, I am expecting to be able to hold `down` and push the jump button to go down through the tile (temporarily make it not collidable).

I am not sure the best way to do that so for now I used a global but am going to explore this more.